### PR TITLE
解决etcd的二进制文件没有执行权限，导致systemctl start etcd失败的问题。

### DIFF
--- a/etcd/deploy-etcd.sh
+++ b/etcd/deploy-etcd.sh
@@ -97,6 +97,7 @@ etcd::deploy()
         etcd::scp "root@${NODE_MAP[$key]}" "${key}.conf" "/etc/etcd/10-etcd.conf"
         etcd::scp "root@${NODE_MAP[$key]}" "etcd.service" "/usr/lib/systemd/system"
         etcd::scp "root@${NODE_MAP[$key]}" "${PWD}/temp-etcd/etcd ${PWD}/temp-etcd/etcdctl" "/usr/bin"
+        etcd::ssh "root@${NODE_MAP[$key]}" "chmod 755 /usr/bin/etcd*"
         etcd::ssh_nowait "root@${NODE_MAP[$key]}" "systemctl daemon-reload && systemctl enable etcd && nohup systemctl start etcd"
     done
 


### PR DESCRIPTION
etcd/temp-etcd/etcd 下载到部署服务器上的/usr/bin/下没有执行权限。进而导致最后一步systemctl start etcd 失败。