### PR TITLE
卸载时清除docker 和 flannel对应的接口。

### DIFF
--- a/k8s-deploy.sh
+++ b/k8s-deploy.sh
@@ -300,6 +300,8 @@ kube::tear_down()
     fi
     rm -rf /var/lib/cni
     ip link del cni0
+    ip link del docker0
+    ip link del flannel.1
 }
 
 main()


### PR DESCRIPTION
卸载时删除docker 和 flannel对应的接口，清除遗留的接口。